### PR TITLE
Fixed misspelled title

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ def test_foo():
       "name":"test_foo",
       "location":"test_example.py#test_foo#2",
       "markers":{
-         "allure_tile":"my title",
+         "allure_title":"my title",
          "allure_description":"description",
          "allure_tag":[
             "tag1",

--- a/pytest_allure_collection/__init__.py
+++ b/pytest_allure_collection/__init__.py
@@ -34,7 +34,7 @@ def pytest_collection(session):
             markers = test.iter_markers()
             title = getattr(test._obj, "__allure_display_name__", None)
             if title:
-                test_dict["markers"]["allure_tile"] = title
+                test_dict["markers"]["allure_title"] = title
             for marker in markers:
                 if marker.name in (
                     ALLURE_DESCRIPTION_MARK,

--- a/tests/data/test_allure_collect_recursive_folder.json
+++ b/tests/data/test_allure_collect_recursive_folder.json
@@ -3,7 +3,7 @@
     "name": "test_foo",
     "location": "test_bar.py::test_foo",
     "markers": {
-      "allure_tile": "my title",
+      "allure_title": "my title",
       "allure_description": "description",
       "allure_tag": [
         "tag1",
@@ -15,7 +15,7 @@
     "name": "test_bar",
     "location": "test_bar.py::test_bar",
     "markers": {
-      "allure_tile": "my title bar",
+      "allure_title": "my title bar",
       "allure_description": "description",
       "allure_tag": [
         "tag1",
@@ -34,7 +34,7 @@
     "name": "test_bar",
     "location": "test_foo.py::test_bar",
     "markers": {
-      "allure_tile": "my title bar",
+      "allure_title": "my title bar",
       "allure_description": "description",
       "allure_tag": [
         "tag1",
@@ -46,7 +46,7 @@
     "name": "test_foo",
     "location": "test_foo.py::test_foo",
     "markers": {
-      "allure_tile": "my title",
+      "allure_title": "my title",
       "allure_description": "description",
       "allure_tag": [
         "tag1",

--- a/tests/data/test_cases_with_class_and_allure_marker.json
+++ b/tests/data/test_cases_with_class_and_allure_marker.json
@@ -3,7 +3,7 @@
     "name": "test_foo",
     "location": "test_cases_with_class_and_allure_marker.py::TestFooClass::test_foo",
     "markers": {
-      "allure_tile": "my title bar",
+      "allure_title": "my title bar",
       "allure_description": "description"
     }
   }

--- a/tests/data/test_multi_cases_with_allure_markers.json
+++ b/tests/data/test_multi_cases_with_allure_markers.json
@@ -3,7 +3,7 @@
     "name": "test_foo",
     "location": "test_multi_cases_with_allure_markers.py::test_foo",
     "markers": {
-      "allure_tile": "my title",
+      "allure_title": "my title",
       "allure_test_case": {
         "url": "case_link",
         "name": "case_link"

--- a/tests/data/test_parameterized_cases_with_class_and_allure_marker.json
+++ b/tests/data/test_parameterized_cases_with_class_and_allure_marker.json
@@ -3,7 +3,7 @@
     "name": "test_foo[1]",
     "location": "test_parameterized_cases_with_class_and_allure_marker.py::TestFooClass::test_foo[1]",
     "markers": {
-      "allure_tile": "my title bar",
+      "allure_title": "my title bar",
       "allure_description": "description"
     }
   },
@@ -11,7 +11,7 @@
     "name": "test_foo[3]",
     "location": "test_parameterized_cases_with_class_and_allure_marker.py::TestFooClass::test_foo[3]",
     "markers": {
-      "allure_tile": "my title bar",
+      "allure_title": "my title bar",
       "allure_description": "description"
     }
   },
@@ -19,7 +19,7 @@
     "name": "test_foo[2]",
     "location": "test_parameterized_cases_with_class_and_allure_marker.py::TestFooClass::test_foo[2]",
     "markers": {
-      "allure_tile": "my title bar",
+      "allure_title": "my title bar",
       "allure_description": "description"
     }
   }

--- a/tests/data/test_with_allure_markers.json
+++ b/tests/data/test_with_allure_markers.json
@@ -3,7 +3,7 @@
     "name": "test_foo",
     "location": "test_with_allure_markers.py::test_foo",
     "markers": {
-      "allure_tile": "my title",
+      "allure_title": "my title",
       "allure_test_case": {
         "url": "case_link",
         "name": "case_link"


### PR DESCRIPTION
 - `allure_title`  was misspelled as `allure_tile`
 - this PR offers a fix
 - README is changed accordingly
 
 Tests pass, I recommend cloning and trying it for yourself as well.